### PR TITLE
Root view replacement in Router protocol

### DIFF
--- a/Sources/Router/Router/Router.swift
+++ b/Sources/Router/Router/Router.swift
@@ -33,6 +33,14 @@ public protocol Router {
         source: RouteViewIdentifier?
     ) -> RouteViewIdentifier where Target: EnvironmentDependentRoute, ThePresenter: Presenter
     
+    /// Replaces the root view of the router with the given `target` route, replacing all current views.
+    @discardableResult
+    func replaceRoot<Target, ThePresenter>(
+        with target: Target,
+        _ environmentObject: Target.EnvironmentObjectDependency,
+        using presenter: ThePresenter
+    ) -> RouteViewIdentifier where Target: EnvironmentDependentRoute, ThePresenter: Presenter
+    
     // MARK: - Dismissal
     
     /// Dismiss up to, but not including, the route matching `id`.
@@ -57,7 +65,7 @@ public extension Router {
     
     // MARK: - Convenience navigation methods
     
-    /// A variation on `navigate(to::using:source:)` without a source.
+    /// A variation on `navigate(to:_:using:source:)` without a source.
     @discardableResult
     func navigate<Target, ThePresenter>(
         to target: Target,
@@ -67,7 +75,7 @@ public extension Router {
         navigate(to: target, environmentObject, using: presenter, source: nil)
     }
     
-    /// A variation on `navigate(to::using:source:)` that uses `DestinationPresenter`.
+    /// A variation on `navigate(to:_:using:source:)` that uses `DestinationPresenter`.
     @discardableResult
     func navigate<Target>(
         to target: Target,
@@ -77,7 +85,7 @@ public extension Router {
         navigate(to: target, environmentObject, using: DestinationPresenter(), source: source)
     }
     
-    /// A variation on `navigate(to::using:source:)` without an EnvironmentObject dependency.
+    /// A variation on `navigate(to:_:using:source:)` without an EnvironmentObject dependency.
     @discardableResult
     func navigate<Target, ThePresenter>(
         to target: Target,
@@ -87,7 +95,7 @@ public extension Router {
         navigate(to: target, VoidObservableObject(), using: presenter, source: source)
     }
     
-    /// A variation on `navigate(to::using:source:)` without an EnvironmentObject dependency that uses `DestinationPresenter`.
+    /// A variation on `navigate(to:_:using:source:)` without an EnvironmentObject dependency that uses `DestinationPresenter`.
     @discardableResult
     func navigate<Target>(
         to target: Target,
@@ -95,4 +103,33 @@ public extension Router {
     ) -> RouteViewIdentifier where Target: Route {
         navigate(to: target, VoidObservableObject(), source: source)
     }
+    
+    // MARK: - Convenience root replacement functions
+    
+    /// A variation of `replaceRoot(with:_:using:)` that uses `DestinationPresenter`.
+    @discardableResult
+    func replaceRoot<Target>(
+        with target: Target,
+        _ environmentObject: Target.EnvironmentObjectDependency
+    ) -> RouteViewIdentifier where Target: EnvironmentDependentRoute {
+        replaceRoot(with: target, environmentObject, using: DestinationPresenter())
+    }
+    
+    /// A variation of `replaceRoot(with:_:using:)` without an EnvironmentObject dependency.
+    @discardableResult
+    func replaceRoot<Target, ThePresenter>(
+        with target: Target,
+        using presenter: ThePresenter
+    ) -> RouteViewIdentifier where Target: Route, ThePresenter: Presenter {
+        replaceRoot(with: target, VoidObservableObject(), using: presenter)
+    }
+    
+    /// A variation of `replaceRoot(witH:_:using:)` without an EnvironmentObject dependency that uses `DestinationPresenter`.
+    @discardableResult
+    func replaceRoot<Target>(
+        with target: Target
+    ) -> RouteViewIdentifier where Target: Route {
+        replaceRoot(with: target, VoidObservableObject(), using: DestinationPresenter())
+    }
+    
 }

--- a/Sources/Router/Router/UINavigationControllerRouter.swift
+++ b/Sources/Router/Router/UINavigationControllerRouter.swift
@@ -74,18 +74,13 @@ open class UINavigationControllerRouter: Router {
     
     // MARK: Root view replacement
     
-    open func replaceRoot<Target: EnvironmentDependentRoute>(
+    open func replaceRoot<Target, ThePresenter>(
         with target: Target,
-        _ environmentObject: Target.EnvironmentObjectDependency
-    ) {
+        _ environmentObject: Target.EnvironmentObjectDependency,
+        using presenter: ThePresenter
+    ) -> RouteViewIdentifier where Target : EnvironmentDependentRoute, ThePresenter : Presenter {
         navigationController.viewControllers = []
-        navigate(to: target, environmentObject, using: DestinationPresenter())
-    }
-    
-    open func replaceRoot<Target: Route>(
-        with target: Target
-    ) {
-        self.replaceRoot(with: target, VoidObservableObject())
+        return navigate(to: target, environmentObject, using: presenter)
     }
     
     // MARK: Navigation

--- a/Sources/Router/Views/RouterLink.swift
+++ b/Sources/Router/Views/RouterLink.swift
@@ -23,10 +23,10 @@ public struct RouterLink<Label: View, Target: EnvironmentDependentRoute>: View {
     ///   - label: A label describing the link.
     ///   - replaceRoot: When set to `true`, the link will use the `replaceRoot` router method instead of `navigate`
     @inlinable
-    public init(to destination: Target, @ViewBuilder label: () -> Label, replaceRoot: Bool = false) {
+    public init(to destination: Target, replaceRoot: Bool = false, @ViewBuilder label: () -> Label) {
         self.target = destination
-        self.label = label()
         self.replaceRoot = replaceRoot
+        self.label = label()
     }
     
     public var body: some View {

--- a/Sources/Router/Views/RouterLink.swift
+++ b/Sources/Router/Views/RouterLink.swift
@@ -14,19 +14,23 @@ public struct RouterLink<Label: View, Target: EnvironmentDependentRoute>: View {
     @usableFromInline
     var label: Label
     
-    @usableFromInline
-    var replaceRoot: Bool
+    var replacesRoot: Bool = false
     
     /// Creates an instance that navigates to `destination`.
     /// - Parameters:
     ///   - destination: The navigation target route.
     ///   - label: A label describing the link.
-    ///   - replaceRoot: When set to `true`, the link will use the `replaceRoot` router method instead of `navigate`
     @inlinable
-    public init(to destination: Target, replaceRoot: Bool = false, @ViewBuilder label: () -> Label) {
+    public init(to destination: Target, @ViewBuilder label: () -> Label) {
         self.target = destination
-        self.replaceRoot = replaceRoot
         self.label = label()
+    }
+    
+    /// Configure a link to use the `replaceRoot` router method instead of `navigate`
+    public func replaceRoot() -> Self {
+        var copy = self
+        copy.replacesRoot = true
+        return copy
     }
     
     public var body: some View {
@@ -38,7 +42,7 @@ public struct RouterLink<Label: View, Target: EnvironmentDependentRoute>: View {
             preconditionFailure("RouterLink needs to be used in a router context")
         }
         
-        if replaceRoot {
+        if replacesRoot {
             router.replaceRoot(with: target, dependency, using: presenter)
         } else {
             router.navigate(to: target, dependency, using: presenter, source: source)

--- a/Sources/Router/Views/RouterLink.swift
+++ b/Sources/Router/Views/RouterLink.swift
@@ -14,14 +14,19 @@ public struct RouterLink<Label: View, Target: EnvironmentDependentRoute>: View {
     @usableFromInline
     var label: Label
     
+    @usableFromInline
+    var replaceRoot: Bool
+    
     /// Creates an instance that navigates to `destination`.
     /// - Parameters:
     ///   - destination: The navigation target route.
     ///   - label: A label describing the link.
+    ///   - replaceRoot: When set to `true`, the link will use the `replaceRoot` router method instead of `navigate`
     @inlinable
-    public init(to destination: Target, @ViewBuilder label: () -> Label) {
+    public init(to destination: Target, @ViewBuilder label: () -> Label, replaceRoot: Bool = false) {
         self.target = destination
         self.label = label()
+        self.replaceRoot = replaceRoot
     }
     
     public var body: some View {
@@ -33,6 +38,10 @@ public struct RouterLink<Label: View, Target: EnvironmentDependentRoute>: View {
             preconditionFailure("RouterLink needs to be used in a router context")
         }
         
-        router.navigate(to: target, dependency, using: presenter, source: source)
+        if replaceRoot {
+            router.replaceRoot(with: target, dependency, using: presenter)
+        } else {
+            router.navigate(to: target, dependency, using: presenter, source: source)
+        }
     }
 }


### PR DESCRIPTION
- Moved `replaceRoot` from `UINavigationControllerRouter` into the `Router` protocol
- Added convenience variations as protocol extension to `Router`, similar to `navigate`
- Added support for `ReplaceRoot` to `RouterLink`