### PR TITLE
Fix root view replacement on iOS 13

### DIFF
--- a/Sources/Router/Router/UINavigationControllerRouter.swift
+++ b/Sources/Router/Router/UINavigationControllerRouter.swift
@@ -120,7 +120,14 @@ open class UINavigationControllerRouter: Router {
         if !presenter.replacesParent { // Push 💨
             let viewController = makeViewController(for: target, environmentObject: environmentObject, using: presenter, routeViewId: targetRouteViewId)
             registerHostingController(hostingController: viewController, byRouteViewId: targetRouteViewId)
-            navigationController.pushViewController(viewController, animated: true)
+            
+            if navigationController.viewControllers.isEmpty {
+                // For some reason, this is needed to work reliably on iOS 13.
+                // On iOS 14, just pusing onto the empty navigation controller works fine.
+                navigationController.viewControllers = [viewController]
+            } else {
+                navigationController.pushViewController(viewController, animated: true)
+            }
         } else {
             let host: RouteHost
             let hostingController: UIHostingController<AnyView>


### PR DESCRIPTION
For some reason, pushing onto an empty navigation controller didn't work on iOS 13. This fixes it.

Root view replacement cannot be animated anyway, so fencing the fix off for iOS 13 only has no advantage while it does sacrifice the simplicity and readability of the code by adding additional control statements.