### PR TITLE
Fix for child router dismissal

### DIFF
--- a/Sources/Router/Presenter/Presenter.swift
+++ b/Sources/Router/Presenter/Presenter.swift
@@ -12,20 +12,16 @@ public protocol Presenter {
 public struct PresentationContext {
     private var _parent: AnyView
     private var _destination: AnyView
-    private var _makeRouter: (AnyView, PresentationContext) -> AnyView
+    private var _makeDestinationRouter: (PresentationContext) -> AnyView
     
-    public typealias RouterViewFactory = (SimpleRoute<Void, AnyView, VoidObservableObject>, PresentationContext) -> AnyView
+    public typealias RouterViewFactory = (PresentationContext) -> AnyView
     
     public init<Parent: View, Destination: View>(parent: Parent, destination: Destination, isPresented: Binding<Bool>, makeRouter: @escaping RouterViewFactory) {
         self._parent = AnyView(parent)
         self._destination = AnyView(destination)
         self._isPresented = isPresented
-        _makeRouter = { wrappedView, `self` in
-            let route = SimpleRoute {
-                AnyView(wrappedView)
-            }
-            
-            return makeRouter(route, self)
+        _makeDestinationRouter = { `self` in
+            return makeRouter(self)
         }
     }
     
@@ -33,12 +29,8 @@ public struct PresentationContext {
         self._parent = parent
         self._destination = destination
         self._isPresented = isPresented
-        _makeRouter = { wrappedView, `self` in
-            let route = SimpleRoute {
-                AnyView(wrappedView)
-            }
-            
-            return makeRouter(route, self)
+        _makeDestinationRouter = { `self` in
+            return makeRouter(self)
         }
     }
     
@@ -46,7 +38,7 @@ public struct PresentationContext {
     public var destination: some View { _destination }
     @Binding public var isPresented: Bool
     
-    public func makeRouter<NestedView: View>(wrapping route: NestedView) -> some View {
-        _makeRouter(AnyView(route), self)
+    public func makeDestinationRouter() -> some View {
+        _makeDestinationRouter(self)
     }
 }

--- a/Sources/Router/Presenter/SheetPresenter.swift
+++ b/Sources/Router/Presenter/SheetPresenter.swift
@@ -15,7 +15,7 @@ public struct SheetPresenter: Presenter {
     public func body(with context: PresentationContext) -> some View {
         context.parent.sheet(isPresented: context.$isPresented) {
             if providesRouter {
-                context.makeRouter(wrapping: context.destination)
+                context.makeDestinationRouter()
             } else {
                 context.destination
             }

--- a/Sources/Router/Router/UINavigationControllerRouter.swift
+++ b/Sources/Router/Router/UINavigationControllerRouter.swift
@@ -161,6 +161,14 @@ open class UINavigationControllerRouter: Router {
                     },
                     set: { newValue in
                         presenterViewModel.isPresented = newValue
+                        
+                        if newValue == false {
+                            // Remove the presenter from the host.
+                            DispatchQueue.main.async {
+                                // Wait until the next iteration of the run loop, for example for sheet modifiers to dismiss themselves before removing them.
+                                hostingController.rootView = host.root
+                            }
+                        }
                     }
                 )
             ) { [unowned self] presentationContext in
@@ -188,7 +196,6 @@ open class UINavigationControllerRouter: Router {
         guard let hostingController = routeHosts[id]?.hostingController else {
             if let (parentRouter, presentationContext) = parentRouter {
                 presentationContext.isPresented = false
-                #warning("When dismissing `self` as a child of `parentRouter`, make sure the current presenter is removed from the hierarchy by replacing the hierarchy with the routeHost.rootView")
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                     parentRouter.dismissUpTo(routeMatchesId: id)
                 }
@@ -206,7 +213,6 @@ open class UINavigationControllerRouter: Router {
         guard let hostingController = routeHosts[id]?.hostingController else {
             if let (parentRouter, presentationContext) = parentRouter {
                 presentationContext.isPresented = false
-                #warning("When dismissing `self` as a child of `parentRouter`, make sure the current presenter is removed from the hierarchy by replacing the hierarchy with the routeHost.rootView")
                 DispatchQueue.main.async {
                     parentRouter.dismissUpTo(routeMatchesId: id)
                 }

--- a/Sources/Router/Router/UINavigationControllerRouter.swift
+++ b/Sources/Router/Router/UINavigationControllerRouter.swift
@@ -99,7 +99,11 @@ open class UINavigationControllerRouter: Router {
     
     /// - note: Not an implementation of the protocol requirement.
     @discardableResult
-    open func navigate<Target, ThePresenter>(to target: Target, _ environmentObject: Target.EnvironmentObjectDependency, using presenter: ThePresenter, source: RouteViewIdentifier?) -> RouteViewIdentifier where Target : EnvironmentDependentRoute, ThePresenter : Presenter {
+    open func navigate<Target, ThePresenter>(
+        to target: Target,
+        _ environmentObject: Target.EnvironmentObjectDependency,
+        using presenter: ThePresenter, source: RouteViewIdentifier?
+    ) -> RouteViewIdentifier where Target : EnvironmentDependentRoute, ThePresenter : Presenter {
         routeHosts.garbageCollect()
         
         func topLevelRouteHostOrNew() -> (RouteHost, UIHostingController<AnyView>) {
@@ -159,8 +163,13 @@ open class UINavigationControllerRouter: Router {
                         presenterViewModel.isPresented = newValue
                     }
                 )
-            ) { [unowned self] rootRoute, presentationContext in
-                self.makeChildRouterView(rootRoute: rootRoute, presentationContext: presentationContext, presenterViewModel: presenterViewModel)
+            ) { [unowned self] presentationContext in
+                self.makeChildRouterView(
+                    rootRoute: target,
+                    environmentObject: environmentObject,
+                    presentationContext: presentationContext,
+                    presenterViewModel: presenterViewModel
+                )
             }
             
             presenterViewModel.$isPresented
@@ -210,8 +219,12 @@ open class UINavigationControllerRouter: Router {
         
         if let viewControllerIndex = navigationController.viewControllers.firstIndex(of: hostingController) {
             if viewControllerIndex == 0 {
-                debugPrint("⚠️ Dismissal of root route is not possible")
-                navigationController.popToRootViewController(animated: true)
+                if let parentRouter = parentRouter {
+                    parentRouter.1.isPresented = false
+                } else {
+                    debugPrint("⚠️ Dismissal of root route is not possible")
+                    navigationController.popToRootViewController(animated: true)
+                }
                 return
             }
             
@@ -228,7 +241,12 @@ open class UINavigationControllerRouter: Router {
     /// Generate the view controller (usually a hosting controller) for the given destination.
     /// - Parameter destination: A destination to route to.
     /// - Returns: A view controller for showing `destination`.
-    open func makeViewController<Target: EnvironmentDependentRoute, ThePresenter: Presenter>(for target: Target, environmentObject: Target.EnvironmentObjectDependency, using presenter: ThePresenter, routeViewId: RouteViewIdentifier) -> UIHostingController<AnyView> {
+    open func makeViewController<Target: EnvironmentDependentRoute, ThePresenter: Presenter>(
+        for target: Target,
+        environmentObject: Target.EnvironmentObjectDependency,
+        using presenter: ThePresenter,
+        routeViewId: RouteViewIdentifier
+    ) -> UIHostingController<AnyView> {
         let state = target.prepareState(environmentObject: environmentObject)
         let presenterViewModel = PresenterViewModel()
         
@@ -236,9 +254,10 @@ open class UINavigationControllerRouter: Router {
             parent: EmptyView(),
             destination: target.body(state: state),
             isPresented: isPresentedBinding(forRouteMatchingId: routeViewId, presenterViewModel: presenterViewModel)
-        ) { [unowned self] rootRoute, presentationContext in
+        ) { [unowned self] presentationContext in
             self.makeChildRouterView(
-                rootRoute: rootRoute,
+                rootRoute: target,
+                environmentObject: environmentObject,
                 presentationContext: presentationContext,
                 presenterViewModel: presenterViewModel
             )
@@ -280,14 +299,15 @@ open class UINavigationControllerRouter: Router {
         return routeHost
     }
     
-    func makeChildRouterView<RootRoute: Route>(
+    func makeChildRouterView<RootRoute: EnvironmentDependentRoute>(
         rootRoute: RootRoute,
+        environmentObject: RootRoute.EnvironmentObjectDependency,
         presentationContext: PresentationContext,
         presenterViewModel: PresenterViewModel
     ) -> AnyView {
         let router = UINavigationControllerRouter(
             root: rootRoute,
-            VoidObservableObject(),
+            environmentObject,
             parent: (self, presentationContext)
         )
         return AnyView(PresenterView(wrappedView: UINavigationControllerRouterView(router: router), viewModel: presenterViewModel))


### PR DESCRIPTION
This PR replaces `PresentationContext.makeRouter(wrapping:)` with `PresentationContext.makeDestinationRouter()`. The destination route itself is then used as the root route within the child router.

Aside from that this PR also improves `UINavigationControllerRouter` so it removes presenters from the view hierarchy when they are not needed anymore, so the two remaining `#warning`s are now solved 😄 